### PR TITLE
Matrix4クラスの代入演算子オーバーロードのプログラムが間違っていた。

### DIFF
--- a/FbxLoader.cpp
+++ b/FbxLoader.cpp
@@ -1,5 +1,6 @@
 ﻿#include "FbxLoader.h"
 #include <cassert>
+#include "DirectXMath.h"
 
 using namespace DirectX;
 
@@ -389,6 +390,17 @@ void FbxLoader::ParseSkin(FbxModel* fbxModel, FbxMesh* fbxMesh)
 		//Matrixr4型に変換
 		Matrix4 initialPose;
 		ConvertMatrix4FromFbx(&initialPose, fbxMat);
+
+		//XMMATRIX initialPoseXM;
+
+		//for (int i = 0; i < 4; i++) {
+		//	for (int j = 0; j < 4; j++) {
+		//		initialPoseXM.r[i].m128_f32[j] = initialPose.m[i][j];
+		//	}
+		//}
+
+		//XMMATRIX invInitialPoseXM = XMMatrixInverse(nullptr, initialPoseXM);
+
 		//初期姿勢行列の逆行列を得る
 		bone.invInitialPose = initialPose.MakeInverse();
 	}

--- a/Matrix4.cpp
+++ b/Matrix4.cpp
@@ -310,6 +310,8 @@ Matrix4& Matrix4::operator*=(const Matrix4& m1)
 		for (int j = 0; j < 4; j++) {
 			float Total = 0.0f;
 			for (int k = 0; k < 4; k++) {
+				float a1 = m[i][k];
+				float a2 = m1.m[k][j];
 				Total += m[i][k] * m1.m[k][j];
 			}
 			result.m[i][j] = Total;
@@ -328,7 +330,9 @@ Matrix4& Matrix4::operator*=(const Matrix4& m1)
 // ２項演算子　*　のオーバーロード関数（行列と行列の積）
 Matrix4 Matrix4::operator*(const Matrix4& m1)
 {
-	return *this *= m1;
+	Matrix4 result = *this;
+
+	return result *= m1;
 }
 
 // ２項演算子　*　のオーバーロード関数（ベクトルと行列の積）


### PR DESCRIPTION
原因:結果を掛け算代入してしまっていたため